### PR TITLE
Fix format-security error in arg

### DIFF
--- a/arg/arg.c
+++ b/arg/arg.c
@@ -899,9 +899,9 @@ void arg_form_print( Arg_form *form )
             fprintf(stderr, "   %d (%s) [%s][%s]%x (%s)\n",
             f->type, f->format, f->flag, f->code, f->parammask, f->doc);
         if (f->type==ARG_SUBLISTFLAG) {
-            fprintf(stderr, bar);
+            fputs(bar, stderr);
             arg_form_print( f->sublist );
-            fprintf(stderr, bar);
+            fputs(bar, stderr);
         }
     }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! Please read this comment in its entirety. It's quite important.
When a contributor merges the pull request, the title and the description will be used to build the merge commit! -->

### Fix format-security error in arg

Opening this PR per geffrak's [recommendation](https://github.com/AcademySoftwareFoundation/OpenRV/issues/15#issuecomment-1850227764)!

<!-- It should be in the following format:

[ 12345: Summary of the changes made ] Where 12345 is the corresponding Github Issue

OR

[ Summary of the changes made ] If it's solving something trivial, like fixing a typo.
-->

### Linked issues

Relates to [OpenRV#15](https://github.com/AcademySoftwareFoundation/OpenRV/issues/15)

### Summarize your change.

This fixes a format-security error in arg when building on Arch Linux.

### Describe the reason for the change.

Building on Arch Linux generates the following error:
```
[421/1885] /usr/bin/cc  -I/home/work/AUR/openrv-git/src/OpenRV/src/pub/arg -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -O3 -DNDEBUG -std=gnu17 -DARCH_IA32_64 -DPLATFORM_LINUX -DTWK_LITTLE_ENDIAN -D__LITTLE_ENDIAN__ -DTWK_NO_SGI_BYTE_ORDER -DGL_GLEXT_PROTOTYPES -DPLATFORM_OPENGL=1 -DMAJOR_VERSION=1 -DMINOR_VERSION=0 -DREVISION_NUMBER=0 -fPIC -fno-schedule-insns -fno-schedule-insns2 -msse -msse2 -mmmx -mfpmath=sse -DNDEBUG -O3 -std=c89 -MD -MT src/pub/arg/CMakeFiles/arg.dir/arg.c.o -MF src/pub/arg/CMakeFiles/arg.dir/arg.c.o.d -o src/pub/arg/CMakeFiles/arg.dir/arg.c.o -c /home/work/AUR/openrv-git/src/OpenRV/src/pub/arg/arg.c
FAILED: src/pub/arg/CMakeFiles/arg.dir/arg.c.o 
/usr/bin/cc  -I/home/work/AUR/openrv-git/src/OpenRV/src/pub/arg -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -O3 -DNDEBUG -std=gnu17 -DARCH_IA32_64 -DPLATFORM_LINUX -DTWK_LITTLE_ENDIAN -D__LITTLE_ENDIAN__ -DTWK_NO_SGI_BYTE_ORDER -DGL_GLEXT_PROTOTYPES -DPLATFORM_OPENGL=1 -DMAJOR_VERSION=1 -DMINOR_VERSION=0 -DREVISION_NUMBER=0 -fPIC -fno-schedule-insns -fno-schedule-insns2 -msse -msse2 -mmmx -mfpmath=sse -DNDEBUG -O3 -std=c89 -MD -MT src/pub/arg/CMakeFiles/arg.dir/arg.c.o -MF src/pub/arg/CMakeFiles/arg.dir/arg.c.o.d -o src/pub/arg/CMakeFiles/arg.dir/arg.c.o -c /home/work/AUR/openrv-git/src/OpenRV/src/pub/arg/arg.c
/home/work/AUR/openrv-git/src/OpenRV/src/pub/arg/arg.c: In function ‘arg_form_print’:
/home/work/AUR/openrv-git/src/OpenRV/src/pub/arg/arg.c:902:13: error: format not a string literal and no format arguments [-Werror=format-security]
  902 |             fprintf(stderr, bar);
      |             ^~~~~~~
/home/work/AUR/openrv-git/src/OpenRV/src/pub/arg/arg.c:904:13: error: format not a string literal and no format arguments [-Werror=format-security]
  904 |             fprintf(stderr, bar);
      |             ^~~~~~~
cc1: some warnings being treated as errors
```
`bar` is [defined](https://github.com/shotgunsoftware/openrv-pub/blob/8d15aa6fd3e4befff6a63ff1ed77c41ea126645c/arg/arg.c#L884) as follows:
```
static char *bar = "==================================================\n";
```
Since there is no string formatting taking place, `fprintf` can be replaced with `fputs` to resolve the build error.

### Describe what you have tested and on which operating system.

This has been built on Arch Linux 6.6.4 using [this](https://aur.archlinux.org/cgit/aur.git/commit/?h=openrv-git&id=10de6b5fa6975a79a8a67e63c3128d2f8269cde2) version of the AUR PKGBUILD.

### Add a list of changes, and note any that might need special attention during the review.

### If possible, provide screenshots.
