### PR TITLE
Fix UB crash in argparse

### DIFF
--- a/arg/arg.c
+++ b/arg/arg.c
@@ -396,27 +396,27 @@ va_list arg_doc_parse(Arg_form *f, va_list ap)
             case 'x': case 'X':
             case 'c':
                 if (size==2 || *s>='A' && *s<='Z') va_arg(ap, long);
-                else va_arg(ap, int);
+                else va_arg(*ap0, int);
                 break;
             case 'e':
             case 'f':
             case 'g':
                 /* note: float args are converted to doubles by MOST compilers*/
-                va_arg(ap, double);
+                va_arg(*ap0, double);
                 break;
             case 's':
-                va_arg(ap, char *);
+                va_arg(*ap0, char *);
                 break;
             default:
                 fprintf(stderr, "arg: unknown format code %%%c in %s\n",
                     *s, f->doc);
-                va_arg(ap, int);
+                va_arg(*ap0, int);
                 break;
         }
     }
     if (gotparam) {     /* there are doc parameters, format a new doc string */
 #ifdef __x86_64__
-        vsprintf(buf, f->doc, (*ap0));
+        vsprintf(buf, f->doc, ap);
 #else
         vsprintf(buf, f->doc, ap0);
 #endif        


### PR DESCRIPTION
The `argparse` library randomly crashes when formatting docstrings with format strings in it.  This is because it's calling `va_arg` on a `va_list` passed in via a function.

From the C standard:
> If access to the varying arguments is desired, the called function shall declare an object (generally referred to as ap in this subclause) having type va_list. The object ap may be passed as an argument to another function; if that function invokes the va_arg macro with parameter ap, the value of ap in the calling function is indeterminate and shall be passed to the va_end macro prior to any further reference to ap.253

`argparse` is violating this when calling the `arg_doc_parse` function.  The function is already making a copy so that it can do the `vsprintf` to resolve the format string arguments while skipping over them in the original by calling `va_arg` to proceed to the next argument. It also copies the copy back over top of the original when the function is done.  

So the simplest fix was just to reverse the logic.  We'll call `va_arg` on the copy instead, so we don't end up in undefined behaviour land, and `vsprintf` on the original.
