### PR TITLE
QtColorTriangle widget background color

### DIFF
--- a/qtcolortriangle/qtcolortriangle.cpp
+++ b/qtcolortriangle/qtcolortriangle.cpp
@@ -212,7 +212,7 @@ void QtColorTriangle::genBackground()
     bg = QImage(contentsRect().size(), QImage::Format_RGB32);
     QPainter p(&bg);
     p.setRenderHint(QPainter::Antialiasing);
-    p.fillRect(bg.rect(), palette().mid());
+    p.fillRect(bg.rect(), palette().window());
 
     QConicalGradient gradient(bg.rect().center(), 90);
     QColor color;


### PR DESCRIPTION
I've been messing around with my OpenRV interface customizations over the last few days. The default fill on the Draw mode color palette doesn't look that great, so I found a way to get it to pick up the interface background color instead. 

Not sure if there are reasons to prefer the brighter color, but I thought I'd propose this change regardless. Thanks!

![openrv](https://github.com/shotgunsoftware/openrv-pub/assets/59420805/f2de4d72-6c37-4b9c-b555-b0c9847f45a9)